### PR TITLE
fix(tests): remove backend async audit warning noise

### DIFF
--- a/backend/tests/test_api_audit_logging.py
+++ b/backend/tests/test_api_audit_logging.py
@@ -8,6 +8,8 @@ from app.crud import audit as audit_crud
 
 @pytest.mark.asyncio
 async def test_audit_failure_is_non_blocking_and_logged(client, monkeypatch, caplog):
+    audit_crud.set_audit_dispatch_enabled(True)
+
     async def _failing_create_audit_event(*args, **kwargs):
         raise RuntimeError("audit write failed")
 


### PR DESCRIPTION
## Summary
- add audit dispatch control + task drain helper in ackend/app/crud/audit.py
- disable async audit dispatch by default for backend tests via autouse fixture in ackend/tests/conftest.py
- keep regression coverage meaningful by explicitly enabling dispatch in ackend/tests/test_api_audit_logging.py

## Why
Backend API tests were passing but noisy with unraisable coroutine warnings (Connection._cancel) from background audit tasks. This obscured real failures and reduced CI signal quality.

## Validation
- cd backend; uv run ruff check app/crud/audit.py tests/conftest.py tests/test_api_audit_logging.py
- cd backend; uv run pytest tests/test_api_audit_logging.py tests/test_api_org_memberships.py tests/test_api_course_memberships.py tests/test_api_invites.py tests/test_api_staff_grading.py tests/test_api_staff_grading_workflow_upgrades.py tests/test_api_resources_and_notifications.py tests/test_api_calendar.py -q

All selected tests pass with warning noise removed.