### PR TITLE
fix(frontend): cap autograder output rendering in submission views

### DIFF
--- a/frontend/src/app/staff/submissions/[id]/page.tsx
+++ b/frontend/src/app/staff/submissions/[id]/page.tsx
@@ -32,6 +32,7 @@ import {
   ApiError,
 } from "@/lib/api";
 import { PdfPreviewModal } from "@/components/shared/PdfPreviewModal";
+import { truncateOutput } from "@/lib/truncateOutput";
 
 const fadeInUp = {
   hidden: { opacity: 0, y: 14 },
@@ -513,7 +514,7 @@ export default function StaffSubmissionDetailPage() {
                         Compile output
                       </p>
                       <pre className="text-xs whitespace-pre-wrap text-[var(--foreground)] font-mono">
-                        {compileOutput}
+                        {truncateOutput(compileOutput)}
                       </pre>
                     </div>
                   ) : null}
@@ -566,7 +567,7 @@ export default function StaffSubmissionDetailPage() {
                               <div className="p-3 rounded-xl bg-[var(--card)] border border-[var(--border)]">
                                 <p className="text-xs text-[var(--muted-foreground)] mb-2">Actual stdout</p>
                                 <pre className="text-xs whitespace-pre-wrap text-[var(--foreground)] font-mono">
-                                  {r.stdout}
+                                  {truncateOutput(r.stdout)}
                                 </pre>
                               </div>
                               <div className="p-3 rounded-xl bg-[var(--card)] border border-[var(--border)]">
@@ -578,7 +579,7 @@ export default function StaffSubmissionDetailPage() {
                               <div className="p-3 rounded-xl bg-[var(--card)] border border-[var(--border)]">
                                 <p className="text-xs text-[var(--muted-foreground)] mb-2">Actual stderr</p>
                                 <pre className="text-xs whitespace-pre-wrap text-[var(--foreground)] font-mono">
-                                  {r.stderr}
+                                  {truncateOutput(r.stderr)}
                                 </pre>
                               </div>
                             </div>

--- a/frontend/src/components/dashboard/student/StudentAssignmentDetailClient.tsx
+++ b/frontend/src/components/dashboard/student/StudentAssignmentDetailClient.tsx
@@ -31,6 +31,7 @@ import {
   type StudentSubmissionTests,
   ApiError,
 } from "@/lib/api";
+import { truncateOutput } from "@/lib/truncateOutput";
 
 const fadeInUp = {
   hidden: { opacity: 0, y: 20 },
@@ -770,7 +771,7 @@ function SubmissionCard({
                   <div className="mt-3">
                     <div className="text-[11px] text-[var(--muted-foreground)] mb-1">Compile output</div>
                     <pre className="text-[11px] whitespace-pre-wrap bg-[var(--muted)]/30 rounded-lg p-2 border border-[var(--border)] overflow-x-auto">
-                      {testsData.compile_output}
+                      {truncateOutput(testsData.compile_output)}
                     </pre>
                   </div>
                 ) : null}
@@ -848,7 +849,7 @@ function SubmissionCard({
                                 <div>
                                   <div className="text-[11px] text-[var(--muted-foreground)] mb-1">Your stdout</div>
                                   <pre className="text-[11px] whitespace-pre-wrap bg-[var(--muted)]/30 rounded-lg p-2 border border-[var(--border)] overflow-x-auto">
-                                    {t.stdout || "∅"}
+                                    {truncateOutput(t.stdout) || "∅"}
                                   </pre>
                                 </div>
                               </div>
@@ -868,7 +869,7 @@ function SubmissionCard({
                                       Your stderr
                                     </div>
                                     <pre className="text-[11px] whitespace-pre-wrap bg-[var(--muted)]/30 rounded-lg p-2 border border-[var(--border)] overflow-x-auto">
-                                      {t.stderr || "∅"}
+                                      {truncateOutput(t.stderr) || "∅"}
                                     </pre>
                                   </div>
                                 </div>

--- a/frontend/src/components/dashboard/student/SubmissionCard.tsx
+++ b/frontend/src/components/dashboard/student/SubmissionCard.tsx
@@ -13,6 +13,7 @@ import {
   CheckCircle2,
 } from "lucide-react";
 import { student, type Submission, type StudentSubmissionTests, ApiError } from "@/lib/api";
+import { truncateOutput } from "@/lib/truncateOutput";
 
 type SubmissionStatus = "pending" | "grading" | "graded" | "error";
 
@@ -310,7 +311,7 @@ export function SubmissionCard({
                   <div className="mt-3">
                     <div className="text-[11px] text-[var(--muted-foreground)] mb-1">Compile output</div>
                     <pre className="text-[11px] whitespace-pre-wrap bg-[var(--muted)]/30 rounded-lg p-2 border border-[var(--border)] overflow-x-auto">
-                      {testsData.compile_output}
+                      {truncateOutput(testsData.compile_output)}
                     </pre>
                   </div>
                 ) : null}
@@ -388,7 +389,7 @@ export function SubmissionCard({
                                 <div>
                                   <div className="text-[11px] text-[var(--muted-foreground)] mb-1">Your stdout</div>
                                   <pre className="text-[11px] whitespace-pre-wrap bg-[var(--muted)]/30 rounded-lg p-2 border border-[var(--border)] overflow-x-auto">
-                                    {t.stdout || "∅"}
+                                    {truncateOutput(t.stdout) || "∅"}
                                   </pre>
                                 </div>
                               </div>
@@ -408,7 +409,7 @@ export function SubmissionCard({
                                       Your stderr
                                     </div>
                                     <pre className="text-[11px] whitespace-pre-wrap bg-[var(--muted)]/30 rounded-lg p-2 border border-[var(--border)] overflow-x-auto">
-                                      {t.stderr || "∅"}
+                                      {truncateOutput(t.stderr) || "∅"}
                                     </pre>
                                   </div>
                                 </div>

--- a/frontend/src/lib/truncateOutput.ts
+++ b/frontend/src/lib/truncateOutput.ts
@@ -1,0 +1,12 @@
+const DEFAULT_MAX_OUTPUT_CHARS = 10_000;
+
+export function truncateOutput(
+  text: string | null | undefined,
+  maxLen: number = DEFAULT_MAX_OUTPUT_CHARS
+): string {
+  const normalized = text ?? "";
+  if (normalized.length <= maxLen) return normalized;
+
+  const hiddenChars = normalized.length - maxLen;
+  return `${normalized.slice(0, maxLen)}\n\n... [truncated, ${hiddenChars.toLocaleString()} chars hidden]`;
+}


### PR DESCRIPTION
## Summary
- add shared 	runcateOutput helper with a 10,000-char display cap
- apply truncation to compile output and actual stdout/stderr in:
  - src/components/dashboard/student/StudentAssignmentDetailClient.tsx
  - src/components/dashboard/student/SubmissionCard.tsx
  - src/app/staff/submissions/[id]/page.tsx
- append clear ... [truncated, N chars hidden] marker when content is clipped

## Validation
- cd frontend; npm run lint -- src/lib/truncateOutput.ts src/components/dashboard/student/StudentAssignmentDetailClient.tsx src/components/dashboard/student/SubmissionCard.tsx src/app/staff/submissions/[id]/page.tsx

Closes #24