### PR TITLE
fix(playground): avoid misleading 'Running...' after compile errors

### DIFF
--- a/frontend/src/app/playground/page.tsx
+++ b/frontend/src/app/playground/page.tsx
@@ -120,7 +120,8 @@ export default function PlaygroundPage() {
         stdin: "",
       });
 
-      const statusLabel = res.compile_output.trim()
+      const isCompileFailure = res.outcome === 11;
+      const statusLabel = isCompileFailure
         ? "Compile error"
         : res.stderr.trim()
           ? "Runtime error"
@@ -132,9 +133,13 @@ export default function PlaygroundPage() {
       if (res.compile_output.trim()) {
         parts.push(res.compile_output.trimEnd());
       }
-      parts.push("Running...");
-      if (res.stdout.trim()) parts.push(res.stdout.trimEnd());
-      if (res.stderr.trim()) parts.push(res.stderr.trimEnd());
+      if (isCompileFailure) {
+        parts.push("Compilation failed.");
+      } else {
+        parts.push("Running...");
+        if (res.stdout.trim()) parts.push(res.stdout.trimEnd());
+        if (res.stderr.trim()) parts.push(res.stderr.trimEnd());
+      }
       parts.push(`\nOutcome code: ${res.outcome}`);
       setOutput(parts.join("\n\n"));
     } catch (err) {


### PR DESCRIPTION
## Summary
- treat JOBE outcome code 11 as compile failure in playground output formatting
- only show Running... and runtime stdout/stderr when compilation succeeds
- add explicit Compilation failed. line for compile-error runs

## Validation
- cd frontend; npm run lint -- src/app/playground/page.tsx

Closes #26