### PR TITLE
fix(api-config): require NEXT_PUBLIC_API_URL in production

### DIFF
--- a/frontend/src/lib/api/core.ts
+++ b/frontend/src/lib/api/core.ts
@@ -2,7 +2,18 @@
  * Shared API client core utilities
  */
 
-export const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+function resolveApiBase(): string {
+  const configured = process.env.NEXT_PUBLIC_API_URL?.trim();
+  if (configured) return configured;
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("NEXT_PUBLIC_API_URL is required in production");
+  }
+
+  return "http://localhost:8000";
+}
+
+export const API_BASE = resolveApiBase();
 
 export class ApiError extends Error {
   constructor(

--- a/frontend/src/lib/api/server.ts
+++ b/frontend/src/lib/api/server.ts
@@ -1,7 +1,5 @@
 import { cookies } from "next/headers";
-import { ApiError } from "@/lib/api";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+import { API_BASE, ApiError } from "./core";
 
 export async function serverApiFetch<T>(
   path: string,


### PR DESCRIPTION
## Summary
- replace silent production fallback in src/lib/api/core.ts with a fail-fast guard
- throw a clear error when NEXT_PUBLIC_API_URL is missing in production
- keep http://localhost:8000 fallback for non-production
- reuse guarded API_BASE from core.ts inside src/lib/api/server.ts to keep behavior consistent

## Validation
- cd frontend; npm run lint -- src/lib/api/core.ts src/lib/api/server.ts

Closes #28